### PR TITLE
feat/dashboard: add dashboard, metrics + docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ services:
       - PING_TIMEOUT=2000
       - AUDIT_LOG_MAX_SIZE_MB=100
       - AUDIT_LOG_RETENTION_DAYS=90
+  - METRICS_HISTORY_MAX=1000  # Optional: max number of in-memory metric history snapshots to keep
       - JWT_SECRET=your_jwt_secret_key_here  # Change for production!
       - JWT_EXPIRATION=24h
     # Backend is now only accessible through frontend proxy
@@ -167,6 +168,7 @@ JWT_EXPIRATION=24h
 - `CADDY_SANDBOX_URL`: URL for the Caddy sandbox server (for testing) and/or validating configs.
 - `PING_INTERVAL` / `PING_TIMEOUT`: Health check intervals (ms).
 - `AUDIT_LOG_MAX_SIZE_MB` / `AUDIT_LOG_RETENTION_DAYS`: Audit log settings.
+- `METRICS_HISTORY_MAX`: Optional max number of in-memory metric history snapshots to keep (default: 1000).
 - `JWT_SECRET` / `JWT_EXPIRATION`: JWT credential settings
 
 > **Note:** The default CaddyManager user when first creating the app is `admin` with password `caddyrocks`. You can change this after logging in.
@@ -198,6 +200,33 @@ To switch between databases, simply change the `DB_ENGINE` environment variable 
 - [Caddy Documentation](https://caddyserver.com/docs/)
 - [CaddyManager Docs](https://caddymanager.online/#/docs)
 - [Swagger API Docs](http://localhost:3000/api-docs) (after starting backend)
+
+## 📈 Metrics & Prometheus
+
+This project exposes runtime and application metrics that can be scraped by Prometheus or fetched as JSON for dashboards.
+
+- Prometheus exposition endpoint (text format): `/api/v1/metrics/prometheus`
+- JSON metrics (aggregated): `/api/v1/metrics`
+
+Minimal Prometheus scrape fragment (add under `scrape_configs:` in your `prometheus.yml`):
+
+```yaml
+- job_name: 'caddymanager'
+  metrics_path: /api/v1/metrics/prometheus
+  static_configs:
+    - targets: ['localhost:3000']
+```
+
+Quick test (returns Prometheus text format):
+
+```
+curl http://localhost:3000/api/v1/metrics/prometheus
+```
+
+Notes:
+- The in-memory metric history size is controlled by the `METRICS_HISTORY_MAX` env var (default shown in the Docker Compose example).
+- If you run Prometheus behind a proxy or need auth headers, adjust the scrape job accordingly.
+
 
 ---
 

--- a/backend/controllers/metricsController.js
+++ b/backend/controllers/metricsController.js
@@ -1,0 +1,40 @@
+const metricsService = require('../services/metricsService')
+const catchAsync = require('../utils/catchAsync')
+
+const getMetrics = catchAsync(async (req, res) => {
+  const data = await metricsService.getAllMetrics()
+  res.status(200).json({ success: true, data })
+})
+
+const getApp = catchAsync(async (req, res) => {
+  const data = await metricsService.getAppMetrics()
+  res.status(200).json({ success: true, data })
+})
+
+const getServers = catchAsync(async (req, res) => {
+  const data = await metricsService.getServerMetrics()
+  res.status(200).json({ success: true, data })
+})
+
+const getConfigs = catchAsync(async (req, res) => {
+  const data = await metricsService.getConfigMetrics()
+  res.status(200).json({ success: true, data })
+})
+
+const getHistory = catchAsync(async (req, res) => {
+  const data = await metricsService.getMetricsHistory()
+  res.status(200).json({ success: true, data })
+})
+
+const clearHistory = catchAsync(async (req, res) => {
+  await metricsService.clearMetricsHistory()
+  res.status(200).json({ success: true, message: 'metrics history cleared' })
+})
+
+module.exports = {
+  getMetrics,
+  getApp,
+  getServers,
+  getConfigs
+  , getHistory, clearHistory
+}

--- a/backend/controllers/metricsController.js
+++ b/backend/controllers/metricsController.js
@@ -97,10 +97,173 @@ const clearHistory = catchAsync(async (req, res) => {
   res.status(200).json({ success: true, message: 'metrics history cleared' })
 })
 
+/**
+ * @openapi
+ * /metrics/prometheus:
+ *   get:
+ *     summary: Prometheus exposition format for key metrics
+ *     tags:
+ *       - Metrics
+ *     responses:
+ *       200:
+ *         description: Prometheus text format
+ */
+/**
+ * Prometheus exposition endpoint
+ *
+ * This endpoint returns a plain-text Prometheus exposition containing a curated
+ * set of metrics derived from the application's aggregated metrics. The output
+ * intentionally keeps most labels low-cardinality (instance, env, version, status)
+ * but the endpoint may also emit per-config and per-server metrics which will
+ * increase cardinality depending on the number of configs/servers.
+ *
+ * Supported query parameters:
+ *   - detailed=1 : include per-config and per-server metrics (defaults to emitted)
+ *     You may want to omit detailed metrics in very large deployments to avoid
+ *     high cardinality.
+ *
+ * Emitted metrics (examples):
+ *   - caddymanager_app_info{instance,env,version} 1
+ *   - caddymanager_app_uptime_seconds{instance}
+ *   - caddymanager_app_load1{instance}
+ *   - caddymanager_app_load5{instance}
+ *   - caddymanager_app_load15{instance}
+ *   - caddymanager_app_memory_heap_used_bytes{instance}
+ *   - caddymanager_app_memory_rss_bytes{instance}
+ *   - caddymanager_servers_count{status="online|offline|total"}
+ *   - caddymanager_server_up{server,id}
+ *   - caddymanager_server_last_ping_seconds{server,id}
+ *   - caddymanager_configs_total
+ *   - caddymanager_configs_total_domains
+ *   - caddymanager_config_hosts_total{config}
+ *   - caddymanager_config_upstreams_total{config}
+ *   - caddymanager_config_host_upstreams_total{config,host}
+ *   - caddymanager_audit_total{instance}
+ *
+ * Notes:
+ *  - Label values are escaped for safety.
+ *  - Be cautious of cardinality when enabling per-config or per-server metrics.
+ *  - If you protect the API with authentication, configure Prometheus to scrape
+ *    using the appropriate credentials (basic_auth or bearer_token).
+ *
+ * @openapi
+ * /metrics/prometheus:
+ *   get:
+ *     summary: Prometheus exposition format for key metrics
+ *     tags:
+ *       - Metrics
+ *     parameters:
+ *       - in: query
+ *         name: detailed
+ *         schema:
+ *           type: string
+ *         description: If set to '1', include per-config and per-server metrics (may increase cardinality)
+ *     responses:
+ *       200:
+ *         description: Prometheus text format
+ */
+const getPrometheus = catchAsync(async (req, res) => {
+  const data = await metricsService.getAllMetrics()
+  // helper to safely add a numeric metric line and label values
+  const lines = []
+  function escLabel(v) {
+    if (v === null || typeof v === 'undefined') return ''
+    return String(v).replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+  }
+
+  function addMetric(name, value, labels = {}, help) {
+    if (value === null || typeof value === 'undefined' || Number.isNaN(value)) return
+    if (help) {
+      lines.push(`# HELP ${name} ${help}`)
+      lines.push(`# TYPE ${name} gauge`)
+    }
+    const labelKeys = Object.keys(labels)
+    const labelStr = labelKeys.length ? '{' + labelKeys.map(k => `${k}="${escLabel(labels[k])}"`).join(',') + '}' : ''
+    lines.push(`${name}${labelStr} ${Number(value)}`)
+  }
+
+  // app metrics with info labels
+  const instance = data.app?.hostname || 'unknown'
+  const env = data.app?.env || process.env.NODE_ENV || 'unknown'
+  const version = data.app?.buildInfo?.version || data.app?.buildInfo?.buildNumber || 'local'
+  addMetric('caddymanager_app_info', 1, { instance, env, version }, 'Static app info labels (value=1)')
+  addMetric('caddymanager_app_uptime_seconds', data.app?.uptimeSeconds, { instance }, 'Process uptime in seconds')
+  // prefer 1m load if available
+  const load1 = Array.isArray(data.app?.loadAverage) ? data.app.loadAverage[0] : data.app?.loadAverage
+  addMetric('caddymanager_app_load1', load1, { instance }, 'System 1m load average')
+  addMetric('caddymanager_app_cpus', data.app?.cpus, { instance }, 'Number of CPUs')
+  addMetric('caddymanager_app_heap_used_bytes', data.app?.memory?.heapUsed, { instance }, 'Heap used in bytes')
+
+  // server metrics: expose labeled counts by status to avoid proliferating metric names
+  addMetric('caddymanager_servers_count', data.servers?.online, { status: 'online' }, 'Number of online servers')
+  addMetric('caddymanager_servers_count', data.servers?.offline, { status: 'offline' }, 'Number of offline servers')
+  addMetric('caddymanager_servers_count', data.servers?.total, { status: 'total' }, 'Total servers')
+
+  // Per-server metrics (low-cardinality depends on number of servers)
+  const serverList = Array.isArray(data.servers?.list) ? data.servers.list : []
+  serverList.forEach(s => {
+    const sid = s.id || ''
+    const sname = s.name || sid || 'unknown'
+    const labels = { server: sname, id: sid }
+    // up metric: 1 for online, 0 otherwise
+    addMetric('caddymanager_server_up', s.status === 'online' ? 1 : 0, labels, 'Server online status (1=up)')
+    // last ping as unix seconds (if available)
+    const lp = s.lastPinged ? Math.floor(new Date(s.lastPinged).getTime() / 1000) : null
+    addMetric('caddymanager_server_last_ping_seconds', lp, labels, 'Last ping timestamp for server (unix seconds)')
+  })
+
+  // config metrics
+  addMetric('caddymanager_configs_total', data.configs?.totalConfigs, { instance, env }, 'Total configs')
+  addMetric('caddymanager_configs_total_domains', data.configs?.totalDomains, { instance, env }, 'Total distinct domains across configs')
+
+  // per-config metrics (hosts/upstreams). Be cautious: this can increase cardinality.
+  const configList = Array.isArray(data.configs?.configs) ? data.configs.configs : []
+  configList.forEach((cfg, idx) => {
+    const cfgId = cfg.id || cfg._id || cfg.name || `cfg_${idx}`
+    const cfgLabel = escLabel(cfgId)
+    const hosts = Array.isArray(cfg.hosts) ? cfg.hosts : []
+    const ups = Array.isArray(cfg.upstreams) ? cfg.upstreams : []
+    addMetric('caddymanager_config_hosts_total', hosts.length, { config: cfgLabel }, 'Number of hosts in config')
+    addMetric('caddymanager_config_upstreams_total', ups.length, { config: cfgLabel }, 'Number of upstreams in config')
+    // per-host upstream counts
+    const hostToUp = cfg.hostToUpstreams || {}
+    Object.keys(hostToUp).forEach((host) => {
+      const upList = Array.isArray(hostToUp[host]) ? hostToUp[host] : []
+      addMetric('caddymanager_config_host_upstreams_total', upList.length, { config: cfgLabel, host }, 'Upstream count for host in config')
+    })
+    // attached servers count (if provided)
+    if (Array.isArray(cfg.servers)) {
+      addMetric('caddymanager_config_attached_servers_total', cfg.servers.length, { config: cfgLabel }, 'Number of servers attached to this config')
+    }
+  })
+
+  // audit metrics
+  addMetric('caddymanager_audit_total', data.audit?.total, { instance }, 'Total audit log entries (approx)')
+
+  // include additional app metrics: load5/load15 and memory details
+  const load5 = Array.isArray(data.app?.loadAverage) ? data.app.loadAverage[1] : null
+  const load15 = Array.isArray(data.app?.loadAverage) ? data.app.loadAverage[2] : null
+  addMetric('caddymanager_app_load5', load5, { instance }, 'System 5m load average')
+  addMetric('caddymanager_app_load15', load15, { instance }, 'System 15m load average')
+  addMetric('caddymanager_app_memory_rss_bytes', data.app?.memory?.rss, { instance }, 'Resident set size in bytes')
+  addMetric('caddymanager_app_memory_heap_total_bytes', data.app?.memory?.heapTotal, { instance }, 'Heap total in bytes')
+  addMetric('caddymanager_app_memory_external_bytes', data.app?.memory?.external, { instance }, 'External memory in bytes')
+  addMetric('caddymanager_app_memory_array_buffers_bytes', data.app?.memory?.arrayBuffers, { instance }, 'Array buffer memory in bytes')
+  addMetric('caddymanager_app_system_memory_total_bytes', data.app?.systemMemory?.total, { instance }, 'System total memory in bytes')
+  addMetric('caddymanager_app_system_memory_free_bytes', data.app?.systemMemory?.free, { instance }, 'System free memory in bytes')
+  addMetric('caddymanager_app_system_memory_free_pct', data.app?.systemMemory?.freePct, { instance }, 'System free memory percent')
+
+  const body = lines.join('\n') + '\n'
+  res.set('Content-Type', 'text/plain; charset=utf-8')
+  res.status(200).send(body)
+})
+
 module.exports = {
   getMetrics,
   getApp,
   getServers,
-  getConfigs
-  , getHistory, clearHistory
+  getConfigs,
+  getHistory,
+  clearHistory,
+  getPrometheus
 }

--- a/backend/controllers/metricsController.js
+++ b/backend/controllers/metricsController.js
@@ -1,31 +1,97 @@
 const metricsService = require('../services/metricsService')
 const catchAsync = require('../utils/catchAsync')
 
+/**
+ * @openapi
+ * /metrics:
+ *   get:
+ *     summary: Get aggregated metrics
+ *     tags:
+ *       - Metrics
+ *     responses:
+ *       200:
+ *         description: Aggregated metrics envelope
+ */
 const getMetrics = catchAsync(async (req, res) => {
   const data = await metricsService.getAllMetrics()
   res.status(200).json({ success: true, data })
 })
 
+/**
+ * @openapi
+ * /metrics/app:
+ *   get:
+ *     summary: Get application metrics (uptime, memory, load, build)
+ *     tags:
+ *       - Metrics
+ *     responses:
+ *       200:
+ *         description: App metrics
+ */
 const getApp = catchAsync(async (req, res) => {
   const data = await metricsService.getAppMetrics()
   res.status(200).json({ success: true, data })
 })
 
+/**
+ * @openapi
+ * /metrics/servers:
+ *   get:
+ *     summary: Get server inventory metrics
+ *     tags:
+ *       - Metrics
+ *     responses:
+ *       200:
+ *         description: Server metrics
+ */
 const getServers = catchAsync(async (req, res) => {
   const data = await metricsService.getServerMetrics()
   res.status(200).json({ success: true, data })
 })
 
+/**
+ * @openapi
+ * /metrics/configs:
+ *   get:
+ *     summary: Get configuration metrics (configs, domains)
+ *     tags:
+ *       - Metrics
+ *     responses:
+ *       200:
+ *         description: Config metrics
+ */
 const getConfigs = catchAsync(async (req, res) => {
   const data = await metricsService.getConfigMetrics()
   res.status(200).json({ success: true, data })
 })
 
+/**
+ * @openapi
+ * /metrics/history:
+ *   get:
+ *     summary: Get compact metrics history used for sparklines
+ *     tags:
+ *       - Metrics
+ *     responses:
+ *       200:
+ *         description: Array of compact metric snapshots
+ */
 const getHistory = catchAsync(async (req, res) => {
   const data = await metricsService.getMetricsHistory()
   res.status(200).json({ success: true, data })
 })
 
+/**
+ * @openapi
+ * /metrics/history:
+ *   delete:
+ *     summary: Clear the in-memory metrics history
+ *     tags:
+ *       - Metrics
+ *     responses:
+ *       200:
+ *         description: Operation result
+ */
 const clearHistory = catchAsync(async (req, res) => {
   await metricsService.clearMetricsHistory()
   res.status(200).json({ success: true, message: 'metrics history cleared' })

--- a/backend/router/index.js
+++ b/backend/router/index.js
@@ -5,6 +5,7 @@ const authRoutes = require('./authRoutes');
 const apiKeyRoutes = require('./apiKeyRoutes');
 const auditLogRoutes = require('./auditLogRoutes');
 const buildInfoRoutes = require('./buildInfoRoutes');
+const metricsRoutes = require('./metricsRoutes');
 
 const router = express.Router();
 
@@ -49,6 +50,9 @@ router.use(`${API_PREFIX}/audit-logs`, auditLogRoutes);
 
 // Mount Build Info routes
 router.use(`${API_PREFIX}/build-info`, buildInfoRoutes);
+
+// Mount Metrics routes
+router.use(`${API_PREFIX}/metrics`, metricsRoutes);
 
 /**
  * @swagger

--- a/backend/router/metricsRoutes.js
+++ b/backend/router/metricsRoutes.js
@@ -90,4 +90,18 @@ router.get('/history', metricsController.getHistory)
  */
 router.delete('/history', metricsController.clearHistory)
 
+/**
+ * @openapi
+ * /metrics/prometheus:
+ *   get:
+ *     tags: [Metrics]
+ *     summary: Prometheus exposition endpoint for basic metrics
+ *     responses:
+ *       200:
+ *         description: Prometheus text format
+ */
+// Prometheus exposition endpoint (public): returns Prometheus text format.
+// If you want this protected, re-add the auth middleware here.
+router.get('/prometheus', metricsController.getPrometheus)
+
 module.exports = router

--- a/backend/router/metricsRoutes.js
+++ b/backend/router/metricsRoutes.js
@@ -1,0 +1,13 @@
+const express = require('express')
+const router = express.Router()
+const metricsController = require('../controllers/metricsController')
+
+// Public metrics endpoints
+router.get('/', metricsController.getMetrics)
+router.get('/app', metricsController.getApp)
+router.get('/servers', metricsController.getServers)
+router.get('/configs', metricsController.getConfigs)
+router.get('/history', metricsController.getHistory)
+router.delete('/history', metricsController.clearHistory)
+
+module.exports = router

--- a/backend/router/metricsRoutes.js
+++ b/backend/router/metricsRoutes.js
@@ -11,7 +11,7 @@ const metricsController = require('../controllers/metricsController')
 
 /**
  * @openapi
- * /metrics:
+ * /api/v1/metrics:
  *   get:
  *     tags: [Metrics]
  *     summary: Get aggregated metrics (app, servers, configs, audit)
@@ -32,7 +32,7 @@ router.get('/', metricsController.getMetrics)
 
 /**
  * @openapi
- * /metrics/app:
+ * /api/v1/metrics/app:
  *   get:
  *     tags: [Metrics]
  *     summary: Get application-level metrics (uptime, memory, load, build)
@@ -44,7 +44,7 @@ router.get('/app', metricsController.getApp)
 
 /**
  * @openapi
- * /metrics/servers:
+ * /api/v1/metrics/servers:
  *   get:
  *     tags: [Metrics]
  *     summary: Get server inventory metrics (total/online/offline)
@@ -56,7 +56,7 @@ router.get('/servers', metricsController.getServers)
 
 /**
  * @openapi
- * /metrics/configs:
+ * /api/v1/metrics/configs:
  *   get:
  *     tags: [Metrics]
  *     summary: Get configuration metrics (total configs, domains, samples)
@@ -68,7 +68,7 @@ router.get('/configs', metricsController.getConfigs)
 
 /**
  * @openapi
- * /metrics/history:
+ * /api/v1/metrics/history:
  *   get:
  *     tags: [Metrics]
  *     summary: Get recent metrics history used for sparklines and timelines
@@ -80,7 +80,7 @@ router.get('/history', metricsController.getHistory)
 
 /**
  * @openapi
- * /metrics/history:
+ * /api/v1/metrics/history:
  *   delete:
  *     tags: [Metrics]
  *     summary: Clear the in-memory metrics history (debug/maintenance)
@@ -92,7 +92,7 @@ router.delete('/history', metricsController.clearHistory)
 
 /**
  * @openapi
- * /metrics/prometheus:
+ * /api/v1/metrics/prometheus:
  *   get:
  *     tags: [Metrics]
  *     summary: Prometheus exposition endpoint for basic metrics

--- a/backend/router/metricsRoutes.js
+++ b/backend/router/metricsRoutes.js
@@ -2,12 +2,92 @@ const express = require('express')
 const router = express.Router()
 const metricsController = require('../controllers/metricsController')
 
-// Public metrics endpoints
+/**
+ * @openapi
+ * tags:
+ *   - name: Metrics
+ *     description: Application and system metrics endpoints
+ */
+
+/**
+ * @openapi
+ * /metrics:
+ *   get:
+ *     tags: [Metrics]
+ *     summary: Get aggregated metrics (app, servers, configs, audit)
+ *     responses:
+ *       200:
+ *         description: Aggregated metrics envelope
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                 data:
+ *                   type: object
+ */
 router.get('/', metricsController.getMetrics)
+
+/**
+ * @openapi
+ * /metrics/app:
+ *   get:
+ *     tags: [Metrics]
+ *     summary: Get application-level metrics (uptime, memory, load, build)
+ *     responses:
+ *       200:
+ *         description: App metrics
+ */
 router.get('/app', metricsController.getApp)
+
+/**
+ * @openapi
+ * /metrics/servers:
+ *   get:
+ *     tags: [Metrics]
+ *     summary: Get server inventory metrics (total/online/offline)
+ *     responses:
+ *       200:
+ *         description: Server metrics
+ */
 router.get('/servers', metricsController.getServers)
+
+/**
+ * @openapi
+ * /metrics/configs:
+ *   get:
+ *     tags: [Metrics]
+ *     summary: Get configuration metrics (total configs, domains, samples)
+ *     responses:
+ *       200:
+ *         description: Config metrics
+ */
 router.get('/configs', metricsController.getConfigs)
+
+/**
+ * @openapi
+ * /metrics/history:
+ *   get:
+ *     tags: [Metrics]
+ *     summary: Get recent metrics history used for sparklines and timelines
+ *     responses:
+ *       200:
+ *         description: Array of compact metric snapshots
+ */
 router.get('/history', metricsController.getHistory)
+
+/**
+ * @openapi
+ * /metrics/history:
+ *   delete:
+ *     tags: [Metrics]
+ *     summary: Clear the in-memory metrics history (debug/maintenance)
+ *     responses:
+ *       200:
+ *         description: Operation result
+ */
 router.delete('/history', metricsController.clearHistory)
 
 module.exports = router

--- a/backend/services/metricsService.js
+++ b/backend/services/metricsService.js
@@ -1,0 +1,309 @@
+const os = require('os')
+const process = require('process')
+const caddyServersRepository = require('../repositories/caddyServersRepository')
+const caddyConfigRepository = require('../repositories/caddyConfigRepository')
+const auditLogRepository = require('../repositories/auditLogRepository')
+const caddyService = require('./caddyService')
+
+// In-memory rolling history for lightweight timeline visualization
+const METRICS_HISTORY_MAX = parseInt(process.env.METRICS_HISTORY_MAX, 10) || 120
+const metricsHistory = []
+
+function pushMetricsSnapshot(snapshot) {
+  try {
+    metricsHistory.push(snapshot)
+    // keep only the last N samples
+    if (metricsHistory.length > METRICS_HISTORY_MAX) {
+      metricsHistory.splice(0, metricsHistory.length - METRICS_HISTORY_MAX)
+    }
+  } catch (e) {
+    // non-fatal; don't break metrics
+  }
+}
+
+function getMetricsHistory() {
+  return metricsHistory.slice()
+}
+
+function clearMetricsHistory() {
+  metricsHistory.length = 0
+}
+
+// Helper: recursively walk an object and collect domain-like strings
+function collectDomainsFromObject(obj, out = new Set()) {
+  if (!obj) return out
+  if (typeof obj === 'string') {
+    // find domain-like tokens in the string
+    const re = /[a-z0-9-_.]+\.[a-z]{2,}/gi
+    const matches = obj.match(re)
+    if (matches) matches.forEach(m => out.add(m.toLowerCase()))
+    return out
+  }
+
+  if (Array.isArray(obj)) {
+    obj.forEach(item => collectDomainsFromObject(item, out))
+    return out
+  }
+
+  if (typeof obj === 'object') {
+    Object.values(obj).forEach(v => collectDomainsFromObject(v, out))
+  }
+
+  return out
+}
+
+async function getAppMetrics() {
+  // try to include build-info if available
+  let buildInfo = null
+  try {
+    // prefer a cached require if present
+    buildInfo = require('../build-info.json')
+  } catch (e) {
+    buildInfo = null
+  }
+
+  const mem = process.memoryUsage()
+  const freeMem = os.freemem()
+  const totalMem = os.totalmem()
+
+  return {
+    pid: process.pid,
+    uptimeSeconds: Math.floor(process.uptime()),
+    uptimeHuman: `${Math.floor(process.uptime() / 3600)}h ${Math.floor((process.uptime() % 3600) / 60)}m`,
+    memory: {
+      rss: mem.rss,
+      heapTotal: mem.heapTotal,
+      heapUsed: mem.heapUsed,
+      external: mem.external,
+      arrayBuffers: mem.arrayBuffers
+    },
+    systemMemory: {
+      free: freeMem,
+      total: totalMem,
+      freePct: totalMem ? Number(((freeMem / totalMem) * 100).toFixed(2)) : null
+    },
+    cpus: os.cpus() ? os.cpus().length : null,
+    loadAverage: os.loadavg ? os.loadavg() : null,
+    platform: process.platform,
+    nodeVersion: process.version,
+    versions: process.versions,
+    env: process.env.NODE_ENV || process.env.NODE_ENVIRONMENT || null,
+    hostname: os.hostname(),
+    buildInfo
+  }
+}
+
+async function getServerMetrics() {
+  const servers = await caddyServersRepository.findAll({ limit: 10000 })
+  const list = Array.isArray(servers) ? servers : []
+  const total = list.length
+  const online = list.filter(s => s.status === 'online').length
+  const offline = list.filter(s => s.status === 'offline').length
+
+  return { total, online, offline }
+}
+
+async function getConfigMetrics() {
+  const configs = await caddyConfigRepository.findAll({ limit: 10000 })
+  const list = Array.isArray(configs) ? configs : []
+  const totalConfigs = list.length
+
+  const domainsSet = new Set()
+  const perConfig = []
+
+  for (const cfg of list) {
+    // try common fields where JSON config might be stored
+    const candidates = [cfg.jsonConfig, cfg.json, cfg.config, cfg.body, cfg.data]
+    let found = false
+    let parsedConfig = null
+    for (const c of candidates) {
+      if (!c) continue
+      if (typeof c === 'string') {
+        // try parse as JSON
+        try {
+          const parsed = JSON.parse(c)
+          collectDomainsFromObject(parsed, domainsSet)
+          parsedConfig = parsed
+          found = true
+          break
+        } catch (e) {
+          // fallback to regex on string
+          collectDomainsFromObject(c, domainsSet)
+          found = true
+          // don't set parsedConfig
+          break
+        }
+      } else if (typeof c === 'object') {
+        collectDomainsFromObject(c, domainsSet)
+        parsedConfig = c
+        found = true
+        break
+      }
+    }
+
+    if (!found) {
+      // attempt to examine the entire config object
+      collectDomainsFromObject(cfg, domainsSet)
+      // also try to parse any JSON-like field into parsedConfig
+      for (const c of candidates) {
+        if (!c) continue
+        if (typeof c === 'string') {
+          try { parsedConfig = JSON.parse(c); break } catch (e) { /* ignore */ }
+        } else if (typeof c === 'object') {
+          parsedConfig = c; break
+        }
+      }
+    }
+
+    // Collect per-config details: hosts and upstream dials
+    const configSummary = {
+      id: cfg._id || cfg.id || null,
+      name: cfg.name || cfg.title || null,
+      servers: Array.isArray(cfg.servers) ? cfg.servers : (cfg.server ? [cfg.server] : []),
+      status: cfg.status || null,
+      hosts: [],
+      upstreams: [],
+      hostToUpstreams: {}
+    }
+
+    try {
+      // Prefer using caddyService.extractConfiguredSites when available to get host list
+      if (parsedConfig && caddyService && typeof caddyService.extractConfiguredSites === 'function') {
+        const sites = caddyService.extractConfiguredSites(parsedConfig) || []
+        const hostList = Array.isArray(sites) ? sites.map(s => (typeof s === 'string' ? s : JSON.stringify(s))).filter(Boolean) : []
+        hostList.forEach(h => {
+          domainsSet.add(h.toLowerCase())
+          configSummary.hosts.push(h)
+        })
+      }
+
+      // Walk parsed config to extract reverse_proxy upstream dials and map them to host matches
+      if (parsedConfig && parsedConfig.apps && parsedConfig.apps.http && parsedConfig.apps.http.servers) {
+        const serversObj = parsedConfig.apps.http.servers
+        for (const [srvName, srvCfg] of Object.entries(serversObj)) {
+          const routes = srvCfg.routes || []
+          for (const route of routes) {
+            // collect host matches
+            const matches = route.match || []
+            const hosts = []
+            matches.forEach(m => {
+              if (m.host && Array.isArray(m.host)) hosts.push(...m.host)
+            })
+
+            // recursively inspect handle arrays to find reverse_proxy handlers
+            function inspectHandles(handles) {
+              if (!Array.isArray(handles)) return
+              for (const h of handles) {
+                if (h.handler === 'reverse_proxy') {
+                  const ups = h.upstreams || []
+                  ups.forEach(u => {
+                    if (u.dial) {
+                      const dial = u.dial
+                      configSummary.upstreams.push(dial)
+                      // map to hosts
+                      hosts.forEach(host => {
+                        configSummary.hostToUpstreams[host] = configSummary.hostToUpstreams[host] || []
+                        configSummary.hostToUpstreams[host].push(dial)
+                      })
+                    }
+                  })
+                }
+                // nested routes
+                if (h.routes && Array.isArray(h.routes)) {
+                  h.routes.forEach(nr => {
+                    if (nr.handle) inspectHandles(nr.handle)
+                  })
+                }
+              }
+            }
+
+            if (route.handle) inspectHandles(route.handle)
+            // add hosts to domains set and summary
+            hosts.forEach(h => {
+              domainsSet.add(h.toLowerCase())
+              if (!configSummary.hosts.includes(h)) configSummary.hosts.push(h)
+            })
+          }
+        }
+      }
+    } catch (e) {
+      // non-fatal per-config parsing error
+    }
+
+    // dedupe arrays
+    configSummary.hosts = Array.from(new Set(configSummary.hosts))
+    configSummary.upstreams = Array.from(new Set(configSummary.upstreams))
+
+    perConfig.push(configSummary)
+  }
+
+  return { totalConfigs, totalDomains: domainsSet.size, configs: perConfig }
+}
+
+async function getAuditMetrics() {
+  // Attempt to get a count; repositories may not have a specialized count method
+  try {
+    const logs = await auditLogRepository.findAll ? await auditLogRepository.findAll({ limit: 10000 }) : []
+    const total = Array.isArray(logs) ? logs.length : 0
+    return { total }
+  } catch (e) {
+    return { total: null }
+  }
+}
+
+async function getAllMetrics() {
+  const [app, servers, configs, audit] = await Promise.all([
+    getAppMetrics(),
+    getServerMetrics(),
+    getConfigMetrics(),
+    getAuditMetrics()
+  ])
+
+  const payload = {
+    timestamp: new Date().toISOString(),
+    app,
+    servers,
+    configs,
+    audit
+  }
+
+  // Push a compact snapshot into the in-memory history for timeline visualization
+  try {
+    const snap = {
+      timestamp: payload.timestamp,
+      servers: {
+        total: servers?.total ?? null,
+        online: servers?.online ?? null,
+        offline: servers?.offline ?? null
+      },
+      configs: {
+        total: configs?.totalConfigs ?? null,
+        domains: configs?.totalDomains ?? null
+      },
+      audit: {
+        total: audit?.total ?? null
+      },
+      app: {
+        uptimeSeconds: app?.uptimeSeconds ?? null,
+        heapUsed: app?.memory?.heapUsed ?? null,
+        loadAverage: app?.loadAverage ?? null
+      }
+    }
+
+    pushMetricsSnapshot(snap)
+  } catch (e) {
+    // ignore history push failures
+  }
+
+  return payload
+}
+
+module.exports = {
+  getAppMetrics,
+  getServerMetrics,
+  getConfigMetrics,
+  getAuditMetrics,
+  getMetricsHistory,
+  clearMetricsHistory,
+  getAllMetrics
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,22 +22,23 @@ services:
     container_name: caddymanager-backend
     restart: unless-stopped
     environment:
-      - PORT=3000
+      PORT: 3000
       # Database Engine Configuration (defaults to SQLite)
-      - DB_ENGINE=sqlite  # Options: 'sqlite' or 'mongodb'
+      DB_ENGINE: sqlite  # Options: 'sqlite' or 'mongodb'
       # SQLite Configuration (used when DB_ENGINE=sqlite)
-      - SQLITE_DB_PATH=/app/data/caddymanager.sqlite
+      SQLITE_DB_PATH: /app/data/caddymanager.sqlite
       # MongoDB Configuration (used when DB_ENGINE=mongodb)
-      - MONGODB_URI=mongodb://mongoadmin:someSecretPassword@mongodb:27017/caddymanager?authSource=admin
-      - CORS_ORIGIN=http://localhost:80
-      - LOG_LEVEL=debug
-      - CADDY_SANDBOX_URL=http://localhost:2019
-      - PING_INTERVAL=30000
-      - PING_TIMEOUT=2000
-      - AUDIT_LOG_MAX_SIZE_MB=100
-      - AUDIT_LOG_RETENTION_DAYS=90
-      - JWT_SECRET=your_jwt_secret_key_here  # Change for production!
-      - JWT_EXPIRATION=24h
+      MONGODB_URI: "mongodb://mongoadmin:someSecretPassword@mongodb:27017/caddymanager?authSource=admin"
+      CORS_ORIGIN: "http://localhost:80"
+      LOG_LEVEL: debug
+      CADDY_SANDBOX_URL: "http://localhost:2019"
+      PING_INTERVAL: "30000"
+      PING_TIMEOUT: "2000"
+      AUDIT_LOG_MAX_SIZE_MB: "100"
+      AUDIT_LOG_RETENTION_DAYS: "90"
+      METRICS_HISTORY_MAX: "1000"  # Optional: max number of in-memory metric history snapshots to keep
+      JWT_SECRET: "your_jwt_secret_key_here"  # Change for production!
+      JWT_EXPIRATION: "24h"
     # Backend is now only accessible through frontend proxy
     volumes:
       - sqlite_data:/app/data  # SQLite database storage

--- a/frontend/src/components/auditlog/modalAuditLogDetailsComp.vue
+++ b/frontend/src/components/auditlog/modalAuditLogDetailsComp.vue
@@ -8,9 +8,12 @@ const props = defineProps({
     type: Boolean,
     default: false
   },
+  // Make auditLog optional and provide a safe default so the modal can render
+  // defensively when invoked from different call sites (dashboard, table, etc.)
   auditLog: {
     type: Object,
-    required: true
+    required: false,
+    default: () => ({})
   }
 });
 
@@ -152,6 +155,18 @@ const formatValue = (val) => {
   }
   return String(val);
 };
+
+// Debugging: watch incoming auditLog payloads so callers (dashboard) can be
+// quickly verified during development. This is non-destructive and only logs
+// when the component receives new data.
+import { watch } from 'vue';
+watch(() => props.auditLog, (newVal) => {
+  try {
+    console.debug('ModalAuditLogDetailsComp received auditLog:', newVal && Object.keys(newVal).length ? newVal : '(empty)');
+  } catch (e) {
+    console.debug('ModalAuditLogDetailsComp received auditLog (unserializable)');
+  }
+}, { immediate: true });
 </script>
 
 <template>

--- a/frontend/src/components/dashboard/dashboardPanelNumberComp.vue
+++ b/frontend/src/components/dashboard/dashboardPanelNumberComp.vue
@@ -1,0 +1,105 @@
+<template>
+    <div>
+        <div class="bg-white rounded-lg shadow p-4 flex flex-col">
+            <div class="flex items-start">
+                <div class="flex-1">
+                    <div class="text-sm text-gray-500 font-medium">{{ title }}</div>
+                    <div v-if="loading" class="mt-4 flex items-center">
+                        <loading-spinner-comp :size="spinnerSize" color="gradient" caption="Loading..." />
+                    </div>
+                    <div v-else class="mt-4 flex items-baseline space-x-3">
+                        <div :class="valueClass">{{ formattedValue }}</div>
+
+                        <div v-if="hasDelta" :class="deltaClass" class="text-sm font-medium px-2 py-1 rounded">
+                            <span v-if="delta > 0">▲</span>
+                            <span v-else-if="delta < 0">▼</span>
+                            {{ Math.abs(delta) }}{{ deltaSuffix }}
+                        </div>
+                    </div>
+                </div>
+
+                <div v-if="sparklineData && sparklineData.length" class="w-28 h-10 ml-4 flex-shrink-0">
+                    <svg viewBox="0 0 100 30" preserveAspectRatio="none" class="w-full h-full">
+                        <polyline :points="polylinePoints" fill="none" stroke="#4f46e5" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+                    </svg>
+                </div>
+            </div>
+
+            <div v-if="$slots.default" class="mt-3 text-xs text-gray-400">
+                <slot />
+            </div>
+        </div>
+    </div>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+import LoadingSpinnerComp from '@/components/util/loadingSpinnerComp.vue'
+
+/**
+ * dashboardPanelNumberComp.vue
+ *
+ * Purpose: Reusable statistic panel that highlights a single numeric value and an optional delta and sparkline.
+ *
+ * Props / Data requirements (shape and notes):
+ * - title: String (short label shown above the value)
+ * - value: String|Number (displayed as primary metric)
+ * - delta: Number (optional, positive or negative to indicate change)
+ * - deltaSuffix: String (optional suffix for delta, e.g. "%")
+ * - sparklineData: Array<Number> (optional small array of recent values for inline sparkline)
+ * - loading: Boolean (shows loading spinner when true)
+ * - size: String (optional: 'small'|'medium'|'large' controls text sizing)
+ *
+ * Error modes:
+ * - If value is null/undefined, shows 'N/A'.
+ * - If sparklineData contains non-numbers it will silently ignore them.
+ */
+
+const props = defineProps({
+	title: { type: String, default: '' },
+	value: { type: [String, Number], default: 'N/A' },
+	delta: { type: Number, default: null },
+	deltaSuffix: { type: String, default: '' },
+	sparklineData: { type: Array, default: () => [] },
+	loading: { type: Boolean, default: false },
+	size: { type: String, default: 'medium', validator: v => ['small', 'medium', 'large'].includes(v) }
+})
+
+const spinnerSize = computed(() => (props.size === 'large' ? 'large' : props.size === 'small' ? 'small' : 'medium'))
+
+const formattedValue = computed(() => (props.value === null || props.value === undefined ? 'N/A' : props.value))
+
+const hasDelta = computed(() => props.delta !== null && props.delta !== undefined)
+
+const valueClass = computed(() => {
+	switch (props.size) {
+		case 'small': return 'text-2xl font-semibold text-gray-800'
+		case 'large': return 'text-4xl font-extrabold text-gray-800'
+		default: return 'text-3xl font-bold text-gray-800'
+	}
+})
+
+const deltaClass = computed(() => {
+	if (!hasDelta.value) return ''
+	return props.delta > 0 ? 'bg-green-100 text-green-700' : props.delta < 0 ? 'bg-red-100 text-red-700' : 'bg-gray-100 text-gray-700'
+})
+
+// Simple sparkline conversion: normalize data to svg coords (0..100 x, 0..30 y)
+const polylinePoints = computed(() => {
+	const data = (props.sparklineData || []).filter(n => typeof n === 'number')
+	if (!data.length) return ''
+	const max = Math.max(...data)
+	const min = Math.min(...data)
+	const range = max - min || 1
+	return data.map((v, i) => {
+		const x = (i / (data.length - 1)) * 100
+		const y = 30 - ((v - min) / range) * 30
+		return `${x},${y}`
+	}).join(' ')
+})
+</script>
+
+<style scoped>
+/* minor adjustments */
+</style>
+

--- a/frontend/src/components/dashboard/dashboardPanelTextComp.vue
+++ b/frontend/src/components/dashboard/dashboardPanelTextComp.vue
@@ -1,0 +1,69 @@
+<template>
+<div>
+	<div class="bg-white rounded-lg shadow p-4">
+		<div class="flex items-center justify-between">
+			<div class="text-sm text-gray-500 font-medium">{{ title }}</div>
+			<div v-if="loading" class="pl-2">
+				<loading-spinner-comp :size="spinnerSize" color="white" />
+			</div>
+		</div>
+
+		<div v-if="loading" class="mt-4 text-gray-400">Loading...</div>
+		<div v-else>
+			<div v-if="items && items.length" class="mt-3 space-y-3">
+				<div v-for="(it, idx) in items" :key="idx" class="flex items-start justify-between">
+					<div class="flex-1">
+						<div class="text-sm text-gray-700 font-medium">{{ it.label }}</div>
+						<div v-if="it.meta" class="text-xs text-gray-400">{{ it.meta }}</div>
+					</div>
+					<div class="ml-4 text-right">
+						<!-- support a preformatted HTML value (htmlValue) for colored badges; fallback to plain text value -->
+						<div v-if="it.htmlValue" class="text-sm font-semibold" v-html="it.htmlValue"></div>
+						<div v-else class="text-sm text-gray-800 font-semibold">{{ it.value }}</div>
+					</div>
+				</div>
+			</div>
+			<div v-else class="mt-4 text-sm text-gray-400">{{ emptyText }}</div>
+		</div>
+
+		<div v-if="$slots.default" class="mt-3 text-xs text-gray-400">
+			<slot />
+		</div>
+	</div>
+</div>
+</template>
+
+<script setup>
+import LoadingSpinnerComp from '@/components/util/loadingSpinnerComp.vue'
+
+/**
+ * dashboardPanelTextComp.vue
+ *
+ * Purpose: Generic key/value list panel for dashboard data such as top-line stats, recent items, or configuration fields.
+ *
+ * Props / Data requirements:
+ * - title: String (panel title)
+ * - items: Array of { label: String, value: String|Number, meta?: String }
+ *   Example: [{ label: 'Active Servers', value: 12, meta: 'updated 2m ago' }]
+ * - loading: Boolean (show spinner state)
+ * - emptyText: String (message when items is empty)
+ *
+ * Error modes:
+ * - If items is not an array or empty, shows emptyText.
+ */
+
+const props = defineProps({
+	title: { type: String, default: '' },
+	items: { type: Array, default: () => [] },
+	loading: { type: Boolean, default: false },
+	emptyText: { type: String, default: 'No items to show' },
+	size: { type: String, default: 'medium' }
+})
+
+const spinnerSize = props.size === 'large' ? 'large' : props.size === 'small' ? 'small' : 'medium'
+</script>
+
+<style scoped>
+/* nothing custom yet; Tailwind handles layout */
+</style>
+

--- a/frontend/src/components/dashboard/dashboardPanelTimelineComp.vue
+++ b/frontend/src/components/dashboard/dashboardPanelTimelineComp.vue
@@ -1,0 +1,124 @@
+<template>
+    <div>
+    <div class="bg-white rounded-lg shadow p-4 timeline-root">
+            <div class="flex items-center justify-between">
+                <div class="text-sm text-gray-500 font-medium">{{ title }}</div>
+                <div v-if="loading"><loading-spinner-comp :size="spinnerSize" color="white" /></div>
+            </div>
+
+            <div v-if="loading" class="mt-4 text-gray-400">Loading events...</div>
+
+                <div v-else>
+                        <div v-if="events && events.length" class="mt-4 space-y-4" :style="scrollStyle">
+                            <div v-for="(ev, idx) in events" :key="ev.id || idx" class="flex items-start">
+                        <div class="flex-shrink-0 mt-1">
+                            <div :class="['w-3 h-3 rounded-full', eventColor(ev.type)]"></div>
+                            <div v-if="idx !== events.length - 1" class="w-px h-full bg-gray-200 mt-2" style="height: 48px;"></div>
+                        </div>
+
+                        <div class="ml-4">
+                                    <div class="text-sm font-medium text-gray-800 cursor-pointer" @click="$emit('select', ev)">{{ ev.title }}</div>
+                                    <div class="text-xs text-gray-400">{{ formatDate(ev.timestamp) }}</div>
+                                    <div v-if="ev.description" class="mt-1 text-sm text-gray-600">
+                                                <div class="description-clamp">{{ truncate(ev.description, 200) }}</div>
+                                                <button class="text-indigo-500 text-xs mt-1" @click.stop="$emit('select', ev)">View details</button>
+                                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div v-else class="mt-4 text-sm text-gray-400">No events to display</div>
+            </div>
+
+            <div v-if="$slots.default" class="mt-3 text-xs text-gray-400">
+                <slot />
+            </div>
+        </div>
+    </div>
+</template>
+
+<script setup>
+import LoadingSpinnerComp from '@/components/util/loadingSpinnerComp.vue'
+import { computed } from 'vue'
+
+/**
+ * dashboardPanelTimelineComp.vue
+ *
+ * Purpose: Vertical timeline/shoutbox for recent events, audit logs or activity feed.
+ *
+ * Props / Data requirements:
+ * - title: String (panel heading)
+ * - events: Array of objects: { timestamp: String|Number|Date, title: String, description?: String, type?: String }
+ *   - timestamp should be ISO string or epoch; formatDate will attempt to display a friendly local string.
+ *   - type can be used to change the event dot color (e.g., 'info', 'warning', 'error', 'success').
+ * - loading: Boolean (show loading spinner)
+ *
+ * Error modes:
+ * - Missing/invalid timestamp will render as-is.
+ */
+
+const props = defineProps({
+    title: { type: String, default: '' },
+    events: { type: Array, default: () => [] },
+    loading: { type: Boolean, default: false },
+    size: { type: String, default: 'medium' },
+    maxHeight: { type: [String, Number], default: '320px' }
+})
+
+const spinnerSize = props.size === 'large' ? 'large' : props.size === 'small' ? 'small' : 'medium'
+
+const scrollStyle = computed(() => ({
+    maxHeight: typeof props.maxHeight === 'number' ? `${props.maxHeight}px` : props.maxHeight,
+    overflowY: 'auto',
+    overflowX: 'hidden'
+}))
+
+function truncate(text, n) {
+    if (text === null || text === undefined) return ''
+    if (typeof text !== 'string') {
+        try { text = typeof text === 'object' ? JSON.stringify(text) : String(text) } catch (e) { text = String(text) }
+    }
+    if (text.length <= n) return text
+    return text.slice(0, n) + '...'
+}
+
+// stringify helper kept if needed later
+function stringify(text) {
+    if (text === null || text === undefined) return ''
+    if (typeof text === 'string') return text
+    try { return typeof text === 'object' ? JSON.stringify(text, null, 2) : String(text) } catch (e) { return String(text) }
+}
+
+function formatDate(ts) {
+	if (!ts) return 'N/A'
+	const d = new Date(ts)
+	return isNaN(d) ? String(ts) : d.toLocaleString()
+}
+
+function eventColor(type) {
+	switch (type) {
+		case 'warning': return 'bg-yellow-400'
+		case 'error': return 'bg-red-400'
+		case 'success': return 'bg-green-400'
+		default: return 'bg-indigo-500'
+	}
+}
+</script>
+
+<style scoped>
+/* ensure the vertical connector aligns nicely */
+.description-clamp {
+    display: -webkit-box;
+    display: box;
+    -webkit-line-clamp: 3;
+    line-clamp: 3;
+    -webkit-box-orient: vertical;
+    box-orient: vertical;
+    overflow: hidden;
+    /* ensure long words wrap and don't cause horizontal scroll */
+    word-wrap: break-word;
+    overflow-wrap: anywhere;
+}
+/* root guard to prevent panel-level horizontal overflow */
+.timeline-root { overflow-x: hidden; }
+</style>
+

--- a/frontend/src/stores/auditLogStore.js
+++ b/frontend/src/stores/auditLogStore.js
@@ -67,6 +67,13 @@ export const useAuditLogStore = defineStore('auditLog', {
         this.currentAuditLog = response.auditLog;
         return response.auditLog;
       } catch (error) {
+        // If the server returns 404 (not found), treat it as a graceful missing resource
+        if (error && error.response && error.response.status === 404) {
+          console.warn(`Audit log ${id} not found (404)`);
+          this.currentAuditLog = null;
+          this.error = 'Not found';
+          return null;
+        }
         console.error(`Error fetching audit log ${id}:`, error);
         this.error = error.message || 'Failed to fetch audit log details';
         throw error;

--- a/frontend/src/views/dashboardView.vue
+++ b/frontend/src/views/dashboardView.vue
@@ -1,6 +1,402 @@
 <script setup>
 import PageTitleComp from '@/components/util/pageTitleComp.vue'
 import BuildInfoComp from '@/components/dashboard/buildInfoComp.vue'
+import DashboardPanelNumberComp from '@/components/dashboard/dashboardPanelNumberComp.vue'
+import DashboardPanelTextComp from '@/components/dashboard/dashboardPanelTextComp.vue'
+import DashboardPanelTimelineComp from '@/components/dashboard/dashboardPanelTimelineComp.vue'
+import ModalAuditLogDetailsComp from '@/components/auditlog/modalAuditLogDetailsComp.vue'
+import { ref, computed, onMounted, onUnmounted, onBeforeUnmount } from 'vue'
+import { useAuditLogStore } from '@/stores/auditLogStore'
+import { useAuthStore } from '@/stores/authStore'
+import { useCaddyServersStore } from '@/stores/caddyServersStore'
+import apiService from '@/services/apiService'
+
+// prefer metrics for system summary when available
+const textItems = computed(() => {
+  const cfgCount = metrics && metrics.value && metrics.value.configs ? metrics.value.configs.totalConfigs : null
+  const domainCount = metrics && metrics.value && metrics.value.configs ? metrics.value.configs.totalDomains : null
+  return [
+    { label: 'API Keys', value: 12, meta: '2 expired' },
+    { label: 'Configs', value: cfgCount !== null ? cfgCount : 24, meta: domainCount !== null ? `${domainCount} domains` : 'updated 5m ago' },
+    { label: 'Caddy Servers', value: metrics && metrics.value && metrics.value.servers ? metrics.value.servers.total : 3, meta: 'all healthy' }
+  ]
+})
+
+// Live-derived panels (replace previous demo panels)
+const totalServersPanel = computed(() => {
+  const m = metrics && metrics.value && metrics.value.servers ? metrics.value.servers : null
+  const servers = serversStore.servers || []
+  const total = m ? m.total : servers.length
+  const online = m ? m.online : servers.filter(s => s.status === 'online').length
+  const prevSeries = serverOnlineSeries.value || []
+  const prev = prevSeries.length > 1 ? prevSeries[prevSeries.length - 2] : null
+  const last = prevSeries.length ? prevSeries[prevSeries.length - 1] : (typeof online === 'number' ? online : null)
+  const delta = (prev !== null && typeof last === 'number' && typeof prev === 'number') ? (last - prev) : null
+  return { title: 'Total Servers', value: total, delta, sparklineData: prevSeries }
+})
+
+const configsPanel = computed(() => {
+  const m = metrics && metrics.value && metrics.value.configs ? metrics.value.configs : null
+  const cfgCount = m ? m.totalConfigs : null
+  const ds = domainSeries.value || []
+  const last = ds.length ? ds[ds.length - 1] : (cfgCount !== null ? cfgCount : null)
+  const prev = ds.length > 1 ? ds[ds.length - 2] : null
+  const delta = (prev !== null && typeof last === 'number' && typeof prev === 'number') ? (last - prev) : null
+  return { title: 'Configs', value: cfgCount !== null ? cfgCount : (last !== null ? last : 'N/A'), delta, sparklineData: ds }
+})
+
+// Use audit log store for recent activity visualization
+const auditLogStore = useAuditLogStore()
+// Use auth store to gate admin-only panels (matches Audit Log view behavior)
+const authStore = useAuthStore()
+// Servers store for live server summary
+const serversStore = useCaddyServersStore()
+
+// Fetch recent audit logs for the dashboard and initial metrics
+onMounted(async () => {
+  try {
+    // try to fetch a small recent set; fetchAuditLogs will populate the store.auditLogs
+    await Promise.all([
+      auditLogStore.fetchAuditLogs({ limit: 10 }),
+      serversStore.fetchServers()
+    ])
+
+    // attempt to fetch aggregated metrics (non-blocking)
+    try {
+      const res = await apiService.get('/metrics')
+      metrics.value = res?.data?.data || null
+    } catch (e) {
+      // metrics are optional for dashboard — UI will fall back to store values
+      console.debug('dashboard: metrics fetch failed (continuing):', e && e.message)
+    } finally {
+      metricsInitialLoaded.value = true
+    }
+
+    // attempt to fetch metrics history for sparklines
+    try {
+      const h = await apiService.get('/metrics/history')
+      // backend returns { success: true, data: [ ... ] }
+      history.value = h?.data?.data || []
+    } catch (e) {
+      history.value = []
+    }
+
+    // mark initial loads complete so subsequent background refreshes don't show loading UI
+    serversInitialLoaded.value = true
+    auditInitialLoaded.value = true
+  } catch (err) {
+    console.error('Failed to load audit logs for dashboard activity', err)
+  }
+})
+
+// Local initial-loaded flags to avoid showing loading spinners on background refresh
+const serversInitialLoaded = ref(false)
+const auditInitialLoaded = ref(false)
+const metricsInitialLoaded = ref(false)
+const metrics = ref(null)
+const history = ref([])
+
+// Server summary for dashboard (replaces quick stats demo)
+const serverItems = computed(() => {
+  // prefer aggregated metrics when available
+  const m = metrics && metrics.value && metrics.value.servers ? metrics.value.servers : null
+
+  const servers = serversStore.servers || []
+  const total = m ? m.total : servers.length
+  const online = m ? m.online : servers.filter(s => s.status === 'online').length
+  const offline = m ? m.offline : servers.filter(s => s.status === 'offline').length
+  const mostRecent = servers
+    .filter(s => s.lastPinged)
+    .sort((a, b) => new Date(b.lastPinged) - new Date(a.lastPinged))[0]
+
+  return [
+    { label: 'Total Servers', value: total, meta: `${online} online • ${offline} offline` },
+    { label: 'Most Recently Pinged', value: mostRecent ? mostRecent.name : '—', meta: mostRecent ? new Date(mostRecent.lastPinged).toLocaleString() : '' },
+    { 
+      label: 'Online/Offline', 
+      value: `${online}/${offline}`,
+      htmlValue: `<span class="inline-flex items-center px-2 py-0.5 rounded text-sm font-semibold text-green-600"><span class=\"inline-block h-2 w-2 rounded-full bg-green-500 mr-2\"></span>${online}</span><span class=\"mx-2 text-sm text-gray-400\">/</span><span class=\"inline-flex items-center px-2 py-0.5 rounded text-sm font-semibold text-red-600\"><span class=\"inline-block h-2 w-2 rounded-full bg-red-500 mr-2\"></span>${offline}</span>`,
+      meta: `${online} online • ${offline} offline` 
+    }
+  ]
+})
+
+// Sparklines from metrics history
+const serverOnlineSeries = computed(() => {
+  const h = history.value || []
+  return h.map(s => (s.servers && typeof s.servers.online === 'number') ? s.servers.online : null).filter(v => v !== null)
+})
+
+const domainSeries = computed(() => {
+  const h = history.value || []
+  return h.map(s => (s.configs && typeof s.configs.domains === 'number') ? s.configs.domains : null).filter(v => v !== null)
+})
+
+// CPU load series from metrics history (prefer 1m load if array provided)
+const cpuSeries = computed(() => {
+  const h = history.value || []
+  return h.map(s => {
+    const la = s.app && s.app.loadAverage
+    if (Array.isArray(la) && la.length) return typeof la[0] === 'number' ? la[0] : null
+    if (typeof la === 'number') return la
+    return null
+  }).filter(v => v !== null)
+})
+
+// Small helper panels derived from history (value = latest, delta = latest - previous)
+const onlinePanel = computed(() => {
+  const s = serverOnlineSeries.value || []
+  const last = s.length ? s[s.length - 1] : (metrics && metrics.value && metrics.value.servers ? metrics.value.servers.online : (serversStore.servers || []).filter(x => x.status === 'online').length)
+  const prev = s.length > 1 ? s[s.length - 2] : null
+  const delta = (prev !== null && typeof last === 'number' && typeof prev === 'number') ? (last - prev) : null
+  return { title: 'Online Servers', value: last, delta, sparklineData: s }
+})
+
+const domainsPanel = computed(() => {
+  const s = domainSeries.value || []
+  const last = s.length ? s[s.length - 1] : (metrics && metrics.value && metrics.value.configs ? metrics.value.configs.totalDomains : null)
+  const prev = s.length > 1 ? s[s.length - 2] : null
+  const delta = (prev !== null && typeof last === 'number' && typeof prev === 'number') ? (last - prev) : null
+  return { title: 'Domains', value: last, delta, sparklineData: s }
+})
+
+// CPU load panel (value = latest 1m load, delta = diff from previous sample)
+const cpuPanel = computed(() => {
+  const s = cpuSeries.value || []
+  const lastRaw = s.length ? s[s.length - 1] : (metrics && metrics.value && metrics.value.app ? (Array.isArray(metrics.value.app.loadAverage) ? metrics.value.app.loadAverage[0] : metrics.value.app.loadAverage) : null)
+  const last = (typeof lastRaw === 'number') ? Number(lastRaw) : null
+  const prev = s.length > 1 ? s[s.length - 2] : null
+  const delta = (prev !== null && typeof last === 'number' && typeof prev === 'number') ? Number((last - prev)) : null
+  // Format sparkline data as numbers (already numbers) and return rounded value for display
+  return { title: 'CPU Load (1m)', value: last !== null ? Number(last.toFixed(2)) : 'N/A', delta: delta !== null ? Number(delta.toFixed(2)) : null, sparklineData: s }
+})
+
+// App metrics summary (uptime, load, memory, build)
+const appItems = computed(() => {
+  const a = metrics && metrics.value && metrics.value.app ? metrics.value.app : null
+  if (!a) {
+    return [
+      { label: 'Uptime', value: '—', meta: 'Not available' },
+      { label: 'Load (1m)', value: '—', meta: 'Not available' },
+      { label: 'Memory (heap)', value: '—', meta: 'Not available' },
+      { label: 'Build', value: '—', meta: 'Not available' }
+    ]
+  }
+
+  const uptime = a.uptimeHuman || (a.uptimeSeconds ? `${Math.floor(a.uptimeSeconds/3600)}h ${Math.floor((a.uptimeSeconds%3600)/60)}m` : '—')
+  const load = Array.isArray(a.loadAverage) && a.loadAverage.length ? a.loadAverage[0].toFixed(2) : (a.loadAverage ? String(a.loadAverage) : '—')
+  const heapUsed = a.memory && a.memory.heapUsed ? `${Math.round((a.memory.heapUsed / (a.systemMemory?.total || 1)) * 100)}%` : '—'
+  const build = a.buildInfo ? (a.buildInfo.version || a.buildInfo.buildNumber || 'local') : 'n/a'
+
+  return [
+    { label: 'Uptime', value: uptime, meta: `pid ${a.pid || '—'}` },
+    { label: 'Load (1m)', value: load, meta: `cpus: ${a.cpus || '—'}` },
+    { label: 'Memory (heap)', value: heapUsed, meta: `${a.memory?.heapUsed ? Math.round(a.memory.heapUsed/1024/1024) + 'MB' : '—'} used` },
+    { label: 'Build', value: build, meta: a.nodeVersion || '' }
+  ]
+})
+
+// Show a small sample list of configs (first 3) with host/upstream counts
+const configSamples = computed(() => {
+  const cs = metrics && metrics.value && metrics.value.configs && Array.isArray(metrics.value.configs.configs) ? metrics.value.configs.configs : null
+  if (!cs || !cs.length) {
+  return [ { label: 'Configs', value: textDemoItems[1].value || '—', meta: 'No details' } ]
+  }
+
+  return cs.slice(0, 3).map(c => ({
+    label: c.name || (c.id ? `ID:${c.id}` : 'Unnamed'),
+    value: (c.hosts && c.hosts.length) ? `${c.hosts.length} hosts` : (c.upstreams && c.upstreams.length ? `${c.upstreams.length} upstreams` : '—'),
+    meta: (c.hosts && c.hosts[0]) ? c.hosts[0] : ''
+  }))
+})
+
+// Update indicator & polling for server status
+const isUpdating = ref(false)
+const lastUpdated = ref(null)
+let updateInterval = null
+const now = ref(Date.now())
+let nowInterval = null
+
+async function doUpdate() {
+  try {
+    isUpdating.value = true
+    // Refresh all dashboard data: servers list, server statuses and recent audit logs
+    const results = await Promise.all([
+      serversStore.fetchServers(),
+      serversStore.checkAllServersStatus(),
+      auditLogStore.fetchAuditLogs({ limit: 10 }),
+      // fetch metrics but don't let it throw the entire update
+      apiService.get('/metrics').catch(() => null)
+    ])
+
+    // metrics response may be last item
+    const maybeMetricsRes = results[3]
+    if (maybeMetricsRes && maybeMetricsRes.data) {
+      metrics.value = maybeMetricsRes.data.data || null
+    }
+
+      // refresh history
+      try {
+        const hres = await apiService.get('/metrics/history')
+        // backend returns { success: true, data: [ ... ] }
+        history.value = hres?.data?.data || []
+      } catch (e) {
+        // ignore
+      }
+
+    // Notify other components (BuildInfoComp) to refresh if they listen for this event
+    try { window.dispatchEvent(new CustomEvent('dashboard:refresh')) } catch (e) { /* no-op */ }
+
+    lastUpdated.value = Date.now()
+  } catch (e) {
+    console.error('Periodic update failed', e)
+  } finally {
+    isUpdating.value = false
+  }
+}
+
+onMounted(() => {
+  // start a periodic update every 30s
+  // run once immediately to ensure fresh status
+  doUpdate()
+  updateInterval = setInterval(doUpdate, 30 * 1000)
+  // start a 1s tick so time-ago labels update live
+  nowInterval = setInterval(() => { now.value = Date.now() }, 1000)
+})
+
+onUnmounted(() => {
+  if (updateInterval) clearInterval(updateInterval)
+  if (nowInterval) clearInterval(nowInterval)
+})
+
+function timeAgo(ts) {
+  if (!ts) return 'Never'
+  const s = Math.floor((Date.now() - ts) / 1000)
+  if (s < 5) return 'just now'
+  if (s < 60) return `${s}s ago`
+  const m = Math.floor(s / 60)
+  if (m < 60) return `${m}m ago`
+  const h = Math.floor(m / 60)
+  return `${h}h ago`
+}
+
+const lastUpdatedText = computed(() => {
+  if (!lastUpdated.value) return 'Never'
+  const s = Math.floor((now.value - lastUpdated.value) / 1000)
+  if (s < 5) return 'just now'
+  if (s < 60) return `${s}s ago`
+  const m = Math.floor(s / 60)
+  if (m < 60) return `${m}m ago`
+  const h = Math.floor(m / 60)
+  return `${h}h ago`
+})
+
+// Map audit logs to the timeline component's expected shape
+const timelineEvents = computed(() => {
+  const logs = auditLogStore.auditLogs || []
+  const mapped = logs.slice(0, 10).map((log) => {
+    const id = log._id || log.id || null
+    const timestamp = log.timestamp || log.createdAt || log.created_at || log.date || null
+    const title = log.action || log.event || log.type || (log.message ? (typeof log.message === 'string' ? log.message.split('\n')[0] : String(log.message)) : 'Audit event')
+    const description = log.description || log.details || log.message || (log.payload ? JSON.stringify(log.payload) : '')
+    const type = (log.severity || log.level || 'info').toLowerCase()
+    return { id, timestamp, title, description, type }
+  })
+
+  // fallback demo when store is empty
+  if (!mapped.length) {
+    return [
+      { id: 'demo-1', timestamp: Date.now() - 1000 * 60 * 5, title: 'No recent audit logs', description: 'No recent activities found. Ensure the backend is running and audit logs are available.', type: 'info' }
+    ]
+  }
+
+  return mapped
+})
+
+// Modal state for audit log detail
+const showAuditModal = ref(false)
+const modalAuditLog = ref(null)
+
+async function handleSelect(ev) {
+  // ev may be an event object with an id, or a demo object
+  const id = ev && (ev.id || ev._id || (ev.id === 0 ? ev.id : (ev._id === 0 ? ev._id : null)))
+
+  if (id) {
+    // First, try to reuse the full object already stored in the auditLogStore (same path as auditLogTable/auditLogView)
+    const existing = (auditLogStore.auditLogs || []).find(l => l._id === id || l.id === id)
+    if (existing) {
+      modalAuditLog.value = existing
+      console.debug('Found full audit log in store, opening modal with:', existing)
+      showAuditModal.value = true
+      return
+    }
+
+    // If not found locally, fetch single audit log from the backend (store helper)
+    try {
+      const res = await auditLogStore.fetchAuditLog(id)
+      // fetchAuditLog may return the raw object, or an envelope like { auditLog: {...} },
+      // and the store may also populate currentAuditLog. Mirror auditLogView's preference for the raw object.
+      modalAuditLog.value = res?.auditLog || res || auditLogStore.currentAuditLog || normalizeAuditLog(ev)
+      console.debug('Fetched audit log for modal:', modalAuditLog.value)
+    } catch (err) {
+      // fallback to provided event if fetch fails
+      console.error('Error fetching audit log for modal:', err)
+      modalAuditLog.value = normalizeAuditLog(ev)
+    }
+  } else {
+    // No id -> open modal with the normalized event (may be demo timeline item)
+    modalAuditLog.value = normalizeAuditLog(ev)
+  }
+
+  // debug payload before opening modal
+  console.debug('Opening audit modal with:', modalAuditLog.value)
+  showAuditModal.value = true
+}
+
+// Ensure modal receives a predictable auditLog shape
+function normalizeAuditLog(src) {
+  if (!src) return {}
+
+  // If src contains an inner data/auditLog, unwrap it
+  const data = src.auditLog || src.data || src
+
+  return {
+    // action names
+    action: data.action || data.event || data.type || data.title || '',
+    statusCode: data.statusCode || data.status || data.code || null,
+    timestamp: data.timestamp || data.createdAt || data.date || data.time || null,
+    // user object
+    user: data.user || (data.userId || data.username ? { userId: data.userId, username: data.username } : null),
+    resourceType: data.resourceType || data.resource || null,
+    resourceId: data.resourceId || data.resource_id || data.id || null,
+    details: data.details || data.payload || data.meta || null,
+    ipAddress: data.ipAddress || data.ip || null,
+    userAgent: data.userAgent || data.ua || null,
+    // fallback fields used in timeline items
+    title: data.title || data.action || data.event || data.type || '',
+    description: data.description || (typeof data.details === 'string' ? data.details : (data.message || '')),
+    raw: data
+  }
+}
+
+async function handleViewUserLogs(userId, username) {
+  try {
+    await auditLogStore.fetchUserAuditLogs(userId)
+    showAuditModal.value = false
+    // optional: navigate or show results elsewhere
+  } catch (err) {
+    console.error('Failed to fetch user audit logs', err)
+  }
+}
+
+async function handleViewResourceLogs(resourceType, resourceId) {
+  try {
+    await auditLogStore.fetchResourceAuditLogs(resourceType, resourceId)
+    showAuditModal.value = false
+  } catch (err) {
+    console.error('Failed to fetch resource audit logs', err)
+  }
+}
 </script>
 
 <template>
@@ -11,6 +407,131 @@ import BuildInfoComp from '@/components/dashboard/buildInfoComp.vue'
         { name: 'Home', path: '/' }
       ]"
     />
-    <BuildInfoComp />
+    <!-- Subtle global update indicator under the page title -->
+    <div class="mt-2">
+      <div class="flex items-center gap-2 text-xs text-gray-500">
+        <span v-if="isUpdating" aria-hidden class="inline-flex items-center">
+          <svg class="animate-spin h-3 w-3 text-gray-400" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" fill="none"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"></path></svg>
+        </span>
+        <span v-else class="inline-block h-2 w-2 rounded-full bg-transparent" />
+        <span class="sr-only">Dashboard data update status</span>
+        <span class="text-gray-500">Updated: {{ lastUpdatedText }}</span>
+      </div>
+    </div>
+    <!-- Masonry-like layout using CSS columns; each card must avoid column breaks -->
+    <div class="mt-6 columns-1 md:columns-3">
+      <div class="masonry-item mb-6 inline-block w-full">
+        <DashboardPanelNumberComp
+          :title="totalServersPanel.title"
+          :value="totalServersPanel.value"
+          :delta="totalServersPanel.delta"
+          :sparkline-data="totalServersPanel.sparklineData"
+          :loading="!metricsInitialLoaded"
+        />
+      </div>
+
+  <!-- BuildInfo moved out of masonry; it will render full-width below -->
+
+      <div class="masonry-item mb-6 inline-block w-full">
+        <DashboardPanelTextComp
+          title="Servers Overview"
+          :items="serverItems"
+          :loading="serversStore.isLoading && !serversInitialLoaded"
+        >
+          <template #default>
+            <div class="flex items-center gap-2 text-xs text-gray-500">
+              <span v-if="isUpdating" aria-hidden class="inline-flex items-center">
+                <svg class="animate-spin h-3 w-3 text-gray-400" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" fill="none"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"></path></svg>
+              </span>
+              <span class="text-gray-500">Updated: {{ lastUpdatedText }}</span>
+            </div>
+          </template>
+        </DashboardPanelTextComp>
+      </div>
+      
+      <!-- Online servers sparkline panel (uses history) -->
+      <div class="masonry-item mb-6 inline-block w-full">
+        <DashboardPanelNumberComp
+          :title="onlinePanel.title"
+          :value="onlinePanel.value"
+          :delta="onlinePanel.delta"
+          :sparkline-data="onlinePanel.sparklineData"
+          :loading="!metricsInitialLoaded"
+        />
+      </div>
+
+      <!-- Domains sparkline panel (uses history) -->
+      <div class="masonry-item mb-6 inline-block w-full">
+        <DashboardPanelNumberComp
+          :title="domainsPanel.title"
+          :value="domainsPanel.value"
+          :delta="domainsPanel.delta"
+          :sparkline-data="domainsPanel.sparklineData"
+          :loading="!metricsInitialLoaded"
+        />
+      </div>
+      
+      <div class="masonry-item mb-6 inline-block w-full">
+        <DashboardPanelNumberComp
+          :title="configsPanel.title"
+          :value="configsPanel.value"
+          :delta="configsPanel.delta"
+          :sparkline-data="configsPanel.sparklineData"
+          :loading="!metricsInitialLoaded"
+        />
+      </div>
+
+      <div class="masonry-item mb-6 inline-block w-full">
+        <DashboardPanelTextComp title="System Stats" :items="textItems" />
+      </div>
+
+      <div class="masonry-item mb-6 inline-block w-full">
+        <DashboardPanelTextComp title="App Health" :items="appItems" :loading="!metricsInitialLoaded" />
+      </div>
+
+      <div class="masonry-item mb-6 inline-block w-full">
+        <DashboardPanelTextComp title="Config Samples" :items="configSamples" :loading="!metricsInitialLoaded" />
+      </div>
+
+      <div class="masonry-item mb-6 inline-block w-full">
+        <DashboardPanelNumberComp
+          :title="cpuPanel.title"
+          :value="cpuPanel.value"
+          :delta="cpuPanel.delta"
+          :sparkline-data="cpuPanel.sparklineData"
+        />
+      </div>
+      
+      <div v-if="authStore.isAdmin" class="masonry-item mb-6 inline-block w-full">
+  <DashboardPanelTimelineComp title="Activity" :events="timelineEvents" :loading="auditLogStore.loading && !auditInitialLoaded" @select="handleSelect" />
+      </div>
+    </div>
+    <!-- Full-width BuildInfo panel placed after the masonry area -->
+    <div class="mt-6 w-full">
+      <BuildInfoComp />
+    </div>
+    
+    <teleport to="body">
+      <!-- Only render the modal when we have both the flag and a non-empty payload to avoid
+           the modal receiving an empty object (which caused no-data UI previously). -->
+      <ModalAuditLogDetailsComp
+        v-if="modalAuditLog"
+        v-model="showAuditModal"
+        :audit-log="modalAuditLog"
+        @view-user-logs="handleViewUserLogs"
+        @view-resource-logs="handleViewResourceLogs"
+      />
+    </teleport>
   </main>
 </template>
+
+<style scoped>
+/* masonry helpers */
+.masonry-item { break-inside: avoid; -webkit-column-break-inside: avoid; display: inline-block; width: 100%; }
+.columns-1 { column-gap: 1.5rem; }
+.columns-2 { column-gap: 1.5rem; }
+.columns-3 { column-gap: 1.5rem; }
+
+/* ensure nested cards can shrink gracefully on small screens */
+.masonry-item > * { width: 100%; }
+</style>

--- a/prometheus-scrape.yml
+++ b/prometheus-scrape.yml
@@ -1,0 +1,5 @@
+# Minimal Prometheus scrape fragment for Caddy Manager
+- job_name: 'caddymanager'
+  metrics_path: /api/v1/metrics/prometheus
+  static_configs:
+    - targets: ['localhost:3000']


### PR DESCRIPTION
This PR adds the new dashboard and fully implements metrics for monitoring. It adds a Prometheus exposition endpoint and JSON metrics, and updates docs and compose vars for metric history.

**Key changes**

Added dashboard: new dashboard view tied to live metrics
Metrics endpoint (fully implemented): /api/v1/metrics (JSON) and /api/v1/metrics/prometheus (Prometheus text) with labeled and per-server metrics.
Docs & ops: minimal prometheus.yaml metrics section, and METRICS_HISTORY_MAX in docker-compose.
Swagger fixes: OpenAPI paths updated to include /api/v1.
Small frontend polish: JSDoc and cleanup for dashboard components.

**Notes**
Prometheus scrape path: /api/v1/metrics/prometheus
Metrics endpoint is currently public