### PR TITLE
Fix: fix api route for keys according to documentation

### DIFF
--- a/backend/router/index.js
+++ b/backend/router/index.js
@@ -43,7 +43,7 @@ router.use(`${API_PREFIX}/convert`, convertRoutes);
 router.use(`${API_PREFIX}/auth`, authRoutes);
 
 // Mount API Key routes
-router.use(`${API_PREFIX}/apikeys`, apiKeyRoutes);
+router.use(`${API_PREFIX}/keys`, apiKeyRoutes);
 
 // Mount Audit Log routes
 router.use(`${API_PREFIX}/audit-logs`, auditLogRoutes);


### PR DESCRIPTION
# In the documentation of the api, it tells you about the routes for the keys:

<img width="407" height="331" alt="image" src="https://github.com/user-attachments/assets/7df4e85e-379f-448b-9259-c6a9a71048bb" />


But the ACTUAL endpoint is:
```ts
router.use(`${API_PREFIX}/apikeys`, apiKeyRoutes);
```

Which leads to a 404 error.

However, it is **__YOUR__** decision if you would rather keep `/api/keys` or `/api/apikeys`.

My personal choice would be `/api/keys`, so the naming scheme would fit and doesn't include the duplicate term "api"