### PR TITLE
fix(docker): install the libcurl4 package for the backend

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -29,7 +29,7 @@ RUN npm ci && chown -R node:node /usr/src/node-app
 
 # Install build dependencies so native modules can be compiled inside the image
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends build-essential python3 libsqlite3-dev && \
+    apt-get install -y --no-install-recommends build-essential libcurl4 python3 libsqlite3-dev && \
     rm -rf /var/lib/apt/lists/*
 
 # Force native modules to build from source inside this image so binaries are


### PR DESCRIPTION
We can see the reason to the issue #69 is the `node:slim` series image does not contains more utility dependencies to let the base image more slim, like this issue said: https://github.com/nodejs/docker-node/issues/1185

So, this PR will fix it by manual install `libcurl4` package in the Dockerfile.