### PR TITLE
Fix frontend env variable docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,13 +130,15 @@ volumes:
 Create a `.env` file in the `frontend/` directory with the following variables:
 
 ```
-API_BASE_URL=http://localhost:3000/api/v1
-APP_NAME=Caddy Manager
-DARK_MODE=true
+VITE_API_BASE_URL=http://localhost:3000/api/v1
+VITE_APP_TITLE=Caddy Manager
+VITE_ENABLE_DARK_MODE=true
 ```
-- `API_BASE_URL`: The base URL for backend API requests - should be the url for your backend api
-- `APP_NAME`: The display name for the app UI.
-- `DARK_MODE`: Set to `true` to enable dark mode by default. Currently not integrated fully.
+- `VITE_API_BASE_URL`: The base URL for backend API requests - should be the url for your backend api.
+- `VITE_APP_TITLE`: The display name for the app UI.
+- `VITE_ENABLE_DARK_MODE`: Set to `true` to enable dark mode by default. Currently not integrated fully.
+
+When running the published frontend Docker image, these values are served by the container's `/config` endpoint. In that mode, use `APP_NAME`, `DARK_MODE`, and `BACKEND_HOST` as shown in the Docker Compose example above.
 
 ### Backend (`backend/.env`)
 Create a `.env` file in the `backend/` directory with the following variables:

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,3 @@
+VITE_API_BASE_URL=http://localhost:3000/api/v1
+VITE_APP_TITLE=Caddy Manager
+VITE_ENABLE_DARK_MODE=true


### PR DESCRIPTION
## Summary
- update the local frontend `.env` docs to use the Vite-prefixed variables read by `frontend/src/services/configService.js`
- add `frontend/.env.example` with the same values
- note that the Docker image still uses `/config` with container env variables such as `APP_NAME`, `DARK_MODE`, and `BACKEND_HOST`

Fixes #85.

## Verification
- `git diff --check`
- Source check: `frontend/src/services/configService.js` reads `VITE_API_BASE_URL`, `VITE_APP_TITLE`, and `VITE_ENABLE_DARK_MODE` for local Vite fallback.